### PR TITLE
[issue-30] [API Data] 論文詳細

### DIFF
--- a/app/Http/Controllers/Api/RonbunController.php
+++ b/app/Http/Controllers/Api/RonbunController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
+use App\Ronbun;
 use Illuminate\Support\Facades\DB;
 
 class RonbunController extends Controller
@@ -12,6 +13,16 @@ class RonbunController extends Controller
     $ronbuns = $this->getLatestRonbuns();
 
     return response()->json($ronbuns);
+  }
+
+  public function show($id)
+  {
+    $ronbun = Ronbun::find($id)
+                ->join('categories', 'ronbuns.category_id', '=', 'categories.id')
+                ->select('ronbuns.*', 'categories.name as category_name')
+                ->first();
+
+    return $ronbun;
   }
 
   public function getLatestRonbuns()

--- a/app/Http/Controllers/Api/RonbunController.php
+++ b/app/Http/Controllers/Api/RonbunController.php
@@ -17,12 +17,9 @@ class RonbunController extends Controller
 
   public function show($id)
   {
-    $ronbun = Ronbun::find($id)
-                ->join('categories', 'ronbuns.category_id', '=', 'categories.id')
-                ->select('ronbuns.*', 'categories.name as category_name')
-                ->first();
+    $ronbun = $this->getRonbun($id);
 
-    return $ronbun;
+    return response()->json($ronbun);
   }
 
   public function getLatestRonbuns()
@@ -35,5 +32,16 @@ class RonbunController extends Controller
                           ->get();
 
     return $latest_ronbuns;
+  }
+
+  public function getRonbun($id)
+  {
+    $ronbun = DB::table('ronbuns')
+                ->where('ronbuns.id', $id)
+                ->join('categories', 'ronbuns.category_id', '=', 'categories.id')
+                ->select('ronbuns.*', 'categories.name as category_name')
+                ->first();
+
+    return $ronbun;
   }
 }

--- a/app/Http/Controllers/Api/RonbunController.php
+++ b/app/Http/Controllers/Api/RonbunController.php
@@ -3,7 +3,6 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
-use App\Ronbun;
 use Illuminate\Support\Facades\DB;
 
 class RonbunController extends Controller

--- a/routes/api.php
+++ b/routes/api.php
@@ -21,4 +21,5 @@ Route::middleware('auth:api')->get('/user', function (Request $request) {
 Route::group(['middleware' => ['api']], function() {
     Route::resource('category/categoryList', 'Api\CategoryController', ['except' => ['create', 'edit']]);
     Route::get('ronbun/ronbunList', 'Api\RonbunController@index');
+    Route::get('ronbun/{id}', 'Api\RonbunController@show');
 });

--- a/tests/Http/Controllers/Api/RonbunControllerTest.php
+++ b/tests/Http/Controllers/Api/RonbunControllerTest.php
@@ -84,6 +84,28 @@ class RonbunControllerTest extends TestCase
     $this->assertEquals('テストカテゴリー', $ronbuns->first()->category_name);
   }
 
+  /** @test */
+  public function 指定したIDの論文情報が取得できる()
+  {
+    $category = $this->createCateogry();
+    $ronbun1 = $this->createRonbun(
+      $title = 'テストタイトル1',
+      $author = 'テスト著者1',
+      $abstract = 'テストテキスト1テストテキスト1テストテキスト1テストテキスト1',
+      $category_id = $category->id,
+    );
+    $ronbun2 = $this->createRonbun(
+      $title = 'テストタイトル2',
+      $author = 'テスト著者2',
+      $abstract = 'テストテキスト2テストテキスト2テストテキスト2テストテキスト2',
+      $category_id = $category->id,
+    );
+
+    $ronbun = (new RonbunController)->show($ronbun1->id);
+
+    $this->assertEquals('テストタイトル1', $ronbun->title);
+  }
+
   private function createRonbun($title, $author, $abstract, $category_id = 1)
   {
     return Ronbun::create([

--- a/tests/Http/Controllers/Api/RonbunControllerTest.php
+++ b/tests/Http/Controllers/Api/RonbunControllerTest.php
@@ -101,7 +101,7 @@ class RonbunControllerTest extends TestCase
       $category_id = $category->id,
     );
 
-    $ronbun = (new RonbunController)->show($ronbun1->id);
+    $ronbun = (new RonbunController)->getRonbun($ronbun1->id);
 
     $this->assertEquals('テストタイトル1', $ronbun->title);
   }


### PR DESCRIPTION
# Issue
#30 

# やったこと
- 指定したIDの論文情報の取得
- APIのrouting設定

# 補足
- APIとして返却するjson

```
{
  "id":12,
  "title":"Miss",
  "author":"\u4e2d\u6d25\u5ddd \u5065\u4e00",
  "year":1973,
  "category_id":9,
  "abstract":"Explicabo non nisi cupiditate. Rerum minus nihil eius facilis aut sint. Error et nesciunt nesciunt nam esse quos.",
  "url":"http:\/\/sakamoto.com\/",
  "user_id":1,
  "thumbnail":"http:\/\/sasaki.com\/nisi-possimus-ex-eos-vel-blanditiis",
  "created_at":"2021-12-01 20:31:11",
  "updated_at":"2021-12-01 20:31:11",
  "category_name":"\u6b6f\u5b66"
}
```