### PR TITLE
[issue-152] laravelからのレスポンスの修正

### DIFF
--- a/app/Http/Controllers/Api/RonbunController.php
+++ b/app/Http/Controllers/Api/RonbunController.php
@@ -24,7 +24,7 @@ class RonbunController extends Controller
     $ronbun = DB::table('ronbuns')
                 ->where('ronbuns.id', $id)
                 ->join('categories', 'ronbuns.category_id', '=', 'categories.id')
-                ->select('ronbuns.*', 'categories.name as category_name')
+                ->select('ronbuns.id', 'ronbuns.abstract', 'ronbuns.author', 'ronbuns.thumbnail', 'ronbuns.title', 'ronbuns.url', 'ronbuns.user_id', 'ronbuns.year', 'categories.name as category_name')
                 ->first();
 
     if (empty($ronbun)) {

--- a/app/Http/Controllers/Api/RonbunListController.php
+++ b/app/Http/Controllers/Api/RonbunListController.php
@@ -37,7 +37,7 @@ class RonbunListController extends Controller
     $ronbunList = DB::table('ronbuns')
                     ->where('ronbuns.category_id', $id)
                     ->join('categories', 'ronbuns.category_id', '=', 'categories.id')
-                    ->select('ronbuns.id', 'ronbuns.title', 'ronbuns.thumbnail', 'categories.name as category_name')
+                    ->select('ronbuns.id', 'ronbuns.title', 'ronbuns.thumbnail', 'ronbuns.category_id', 'categories.name as category_name')
                     ->get();
 
       return $ronbunList;

--- a/app/Http/Controllers/Api/RonbunListController.php
+++ b/app/Http/Controllers/Api/RonbunListController.php
@@ -25,7 +25,7 @@ class RonbunListController extends Controller
   {
     $ronbunList = DB::table('ronbuns')
                     ->join('categories', 'ronbuns.category_id', '=', 'categories.id')
-                    ->select('ronbuns.*', 'categories.name as category_name')
+                    ->select('ronbuns.id', 'ronbuns.title', 'ronbuns.thumbnail', 'categories.name as category_name')
                     ->orderBy('ronbuns.updated_at', 'desc')
                     ->get();
 
@@ -37,7 +37,7 @@ class RonbunListController extends Controller
     $ronbunList = DB::table('ronbuns')
                     ->where('ronbuns.category_id', $id)
                     ->join('categories', 'ronbuns.category_id', '=', 'categories.id')
-                    ->select('ronbuns.*', 'categories.name as category_name')
+                    ->select('ronbuns.id', 'ronbuns.title', 'ronbuns.thumbnail', 'categories.name as category_name')
                     ->get();
 
       return $ronbunList;

--- a/app/Http/Controllers/Api/TopController.php
+++ b/app/Http/Controllers/Api/TopController.php
@@ -25,7 +25,7 @@ class TopController extends Controller
   {
     $latest_ronbuns = DB::table('ronbuns')
                           ->leftJoin('categories', 'ronbuns.category_id', '=', 'categories.id')
-                          ->select('ronbuns.*', 'categories.name as category_name')
+                          ->select('ronbuns.id', 'ronbuns.title', 'ronbuns.thumbnail', 'categories.name as category_name')
                           ->orderBy('ronbuns.updated_at', 'desc')
                           ->limit(4)
                           ->get();

--- a/frontend/src/components/ui-p-page/DupPageTop.tsx
+++ b/frontend/src/components/ui-p-page/DupPageTop.tsx
@@ -18,8 +18,6 @@ import { DomPageTop } from './DomPageTop';
 import { useCategories } from '../../hooks/top/useCategories';
 
 export const DupPageTop: React.FC = () => {
-  const [loading, setLoading] = useState(false);
-
   const {
     data: latests,
     isLoading: latestLoading,

--- a/frontend/src/hooks/top/useLatestRonbuns.ts
+++ b/frontend/src/hooks/top/useLatestRonbuns.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import { useQuery } from 'react-query';
-import { RonbunResponse } from '../useRonbun';
+import { RonbunCardResponse } from '../useRonbun';
 
 const getLatestRonbuns = async () => {
   const url = '/api/top/latestList';
@@ -10,5 +10,8 @@ const getLatestRonbuns = async () => {
 };
 
 export const useLatestRonbuns = () => {
-  return useQuery<Array<RonbunResponse>>('latest_ronbuns', getLatestRonbuns);
+  return useQuery<Array<RonbunCardResponse>>(
+    'latest_ronbuns',
+    getLatestRonbuns
+  );
 };

--- a/frontend/src/hooks/useCategoryRonbuns.ts
+++ b/frontend/src/hooks/useCategoryRonbuns.ts
@@ -1,6 +1,13 @@
 import axios from 'axios';
 import { useQuery } from 'react-query';
-import { RonbunResponse } from './useRonbun';
+
+type CategoryRonbunCardResponse = {
+  id: number;
+  thumbnail: string;
+  title: string;
+  category_id: number;
+  category_name: string;
+};
 
 const getCategoryRonbuns = async (category_id: number) => {
   const url = `/api/category/${category_id}/ronbunList`;
@@ -11,7 +18,8 @@ const getCategoryRonbuns = async (category_id: number) => {
 };
 
 export const useCategoryRonbuns = (category_id: number) => {
-  return useQuery<Array<RonbunResponse>>(['category_ronbun', category_id], () =>
-    getCategoryRonbuns(category_id)
+  return useQuery<Array<CategoryRonbunCardResponse>>(
+    ['category_ronbun', category_id],
+    () => getCategoryRonbuns(category_id)
   );
 };

--- a/frontend/src/hooks/useCategoryRonbuns.ts
+++ b/frontend/src/hooks/useCategoryRonbuns.ts
@@ -12,14 +12,13 @@ type CategoryRonbunCardResponse = {
 const getCategoryRonbuns = async (category_id: number) => {
   const url = `/api/category/${category_id}/ronbunList`;
 
-  const { data } = await axios.post(url, { category_id });
+  const { data } = await axios.get(url);
 
   return data;
 };
 
 export const useCategoryRonbuns = (category_id: number) => {
-  return useQuery<Array<CategoryRonbunCardResponse>>(
-    ['category_ronbun', category_id],
-    () => getCategoryRonbuns(category_id)
+  return useQuery<Array<CategoryRonbunCardResponse>>('category_ronbun', () =>
+    getCategoryRonbuns(category_id)
   );
 };

--- a/frontend/src/hooks/useRonbun.ts
+++ b/frontend/src/hooks/useRonbun.ts
@@ -26,11 +26,11 @@ export type RonbunCardResponse = {
 const getRonbun = async (id: number) => {
   const url = `/api/ronbun/${id}`;
 
-  const { data } = await axios.post(url, { id });
+  const { data } = await axios.get(url);
 
   return data;
 };
 
 export const useRonbun = (id: number) => {
-  return useQuery<RonbunResponse>(['ronbun', id], () => getRonbun(id));
+  return useQuery<RonbunResponse>('ronbun', () => getRonbun(id));
 };

--- a/frontend/src/hooks/useRonbun.ts
+++ b/frontend/src/hooks/useRonbun.ts
@@ -16,6 +16,13 @@ export type RonbunResponse = {
   category_name: string;
 };
 
+export type RonbunCardResponse = {
+  id: number;
+  thumbnail: string;
+  title: string;
+  category_name: string;
+};
+
 const getRonbun = async (id: number) => {
   const url = `/api/ronbun/${id}`;
 

--- a/frontend/src/hooks/useRonbuns.ts
+++ b/frontend/src/hooks/useRonbuns.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import { useQuery } from 'react-query';
-import { RonbunResponse } from './useRonbun';
+import { RonbunCardResponse } from './useRonbun';
 
 const getRonbuns = async () => {
   const url = '/api/latestList';
@@ -11,5 +11,5 @@ const getRonbuns = async () => {
 };
 
 export const useRonbuns = () => {
-  return useQuery<Array<RonbunResponse>>('ronbuns', getRonbuns);
+  return useQuery<Array<RonbunCardResponse>>('ronbuns', getRonbuns);
 };

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -2073,7 +2073,6 @@ __webpack_require__.r(__webpack_exports__);
 
 
 const DupPageTop = () => {
-    const [loading, setLoading] = Object(react__WEBPACK_IMPORTED_MODULE_1__["useState"])(false);
     const { data: latests, isLoading: latestLoading, error: latestError, } = Object(_hooks_top_useLatestRonbuns__WEBPACK_IMPORTED_MODULE_0__["useLatestRonbuns"])();
     const { data: categories, isLoading: categoriesLoading, error: categoriesError, } = Object(_hooks_top_useCategories__WEBPACK_IMPORTED_MODULE_15__["useCategories"])();
     // TODO: !loadingのところ何回も書かないといけないので直したい。。。

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -2395,11 +2395,11 @@ var __awaiter = (undefined && undefined.__awaiter) || function (thisArg, _argume
 
 const getCategoryRonbuns = (category_id) => __awaiter(void 0, void 0, void 0, function* () {
     const url = `/api/category/${category_id}/ronbunList`;
-    const { data } = yield axios__WEBPACK_IMPORTED_MODULE_0___default.a.post(url, { category_id });
+    const { data } = yield axios__WEBPACK_IMPORTED_MODULE_0___default.a.get(url);
     return data;
 });
 const useCategoryRonbuns = (category_id) => {
-    return Object(react_query__WEBPACK_IMPORTED_MODULE_1__["useQuery"])(['category_ronbun', category_id], () => getCategoryRonbuns(category_id));
+    return Object(react_query__WEBPACK_IMPORTED_MODULE_1__["useQuery"])('category_ronbun', () => getCategoryRonbuns(category_id));
 };
 
 
@@ -2431,11 +2431,11 @@ var __awaiter = (undefined && undefined.__awaiter) || function (thisArg, _argume
 
 const getRonbun = (id) => __awaiter(void 0, void 0, void 0, function* () {
     const url = `/api/ronbun/${id}`;
-    const { data } = yield axios__WEBPACK_IMPORTED_MODULE_0___default.a.post(url, { id });
+    const { data } = yield axios__WEBPACK_IMPORTED_MODULE_0___default.a.get(url);
     return data;
 });
 const useRonbun = (id) => {
-    return Object(react_query__WEBPACK_IMPORTED_MODULE_1__["useQuery"])(['ronbun', id], () => getRonbun(id));
+    return Object(react_query__WEBPACK_IMPORTED_MODULE_1__["useQuery"])('ronbun', () => getRonbun(id));
 };
 
 

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,4 +1,4 @@
 {
-    "/js/app.js": "/js/app.js?id=b021b5696b7815586943",
+    "/js/app.js": "/js/app.js?id=77a3d5f200baa8d24f1c",
     "/css/app.css": "/css/app.css?id=6332612009a93cd6a053"
 }

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,4 +1,4 @@
 {
-    "/js/app.js": "/js/app.js?id=4e6f05fdc23c4961ef43",
+    "/js/app.js": "/js/app.js?id=b021b5696b7815586943",
     "/css/app.css": "/css/app.css?id=6332612009a93cd6a053"
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -28,6 +28,6 @@ Route::group(['middleware' => ['api']], function() {
   // 一覧
   Route::get('/latestList', 'Api\RonbunListController@index');
 
-  Route::post('/ronbun/{id}', 'Api\RonbunController@index');
-  Route::post('/category/{category_id}/ronbunList', 'Api\RonbunListController@category');
+  Route::get('/ronbun/{id}', 'Api\RonbunController@index');
+  Route::get('/category/{category_id}/ronbunList', 'Api\RonbunListController@category');
 });


### PR DESCRIPTION
# Issue
#152 

# 詳細
- APIレスポンスには、フロントで必要なものしか入れないようにするため、取得するものを制限
- 論文レスポンスの型を修正
- 論文詳細と、カテゴリーはgetで取得する

# 動作確認
